### PR TITLE
Feature/http status code

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const angularRules = require('./lib/rules/angular/index.js');
 const advancedRules = require('./lib/rules/advanced/index.js');
 const flatConfigBase = require('./configs/flat-config-base.js');
 const legacyConfigBase = require('./configs/legacy-config-base.js');
+const expressRules = require('./lib/rules/node/express/open-api-spec/index.js');
 const { name, version } = require('./package.json');
 
 // Helper function to convert rule definitions to rule configurations for legacy config
@@ -65,6 +66,7 @@ const hub = {
     ...reactRules.rules,
     ...angularRules.rules,
     ...advancedRules.rules,
+    ...expressRules.rules,
   },
 };
 
@@ -76,6 +78,7 @@ const configs = {
   react: createConfig(convertRulesToLegacyConfig(reactRules.rules)),
   angular: createConfig(convertRulesToLegacyConfig(angularRules.rules)),
   advanced: createConfig(convertRulesToLegacyConfig(advancedRules.rules)),
+  express: createConfig(convertRulesToLegacyConfig(expressRules.rules)),
   mern: createConfig(mernRecommendedRulesLegacy),
 
   // Flat format configurations
@@ -96,6 +99,12 @@ const configs = {
     convertRulesToFlatConfig(advancedRules.rules),
     'hub/flat/advanced'
   ),
+
+  'flat/express': createConfig(
+    convertRulesToFlatConfig(expressRules.rules),
+    'hub/flat/express'
+  ),
+
   'flat/mern': createConfig(mernRecommendedRulesFlat, 'hub/flat/mern'),
 };
 

--- a/index.mjs
+++ b/index.mjs
@@ -3,8 +3,12 @@ import generalRules from './lib/rules/general/index.js';
 import reactRules from './lib/rules/react/index.js';
 import angularRules from './lib/rules/angular/index.js';
 import advancedRules from './lib/rules/advanced/index.js';
+
+import expressRules from './lib/rules/node/express/open-api-spec/index.js';
+
 import flatConfigBase from './configs/flat-config-base.mjs';
 import legacyConfigBase from './configs/legacy-config-base.mjs';
+
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { readFileSync } from 'fs';
@@ -74,6 +78,7 @@ const hub = {
     ...reactRules.rules,
     ...angularRules.rules,
     ...advancedRules.rules,
+    ...expressRules.rules,
   },
 };
 
@@ -85,6 +90,7 @@ const configs = {
   react: createConfig(convertRulesToLegacyConfig(reactRules.rules)),
   angular: createConfig(convertRulesToLegacyConfig(angularRules.rules)),
   advanced: createConfig(convertRulesToLegacyConfig(advancedRules.rules)),
+  express: createConfig(convertRulesToLegacyConfig(expressRules.rules)),
   mern: createConfig(mernRecommendedRulesLegacy),
 
   // Flat format configurations
@@ -102,6 +108,9 @@ const configs = {
     'hub/flat/angular'
   ),
   'flat/advanced': createConfig(convertRulesToFlatConfig(advancedRules.rules), 'hub/flat/advanced'),
+
+  'flat/express': createConfig(convertRulesToFlatConfig(expressRules.rules), 'hub/flat/express'),
+  
   'flat/mern': createConfig(mernRecommendedRulesFlat, 'hub/flat/mern'),
 };
 

--- a/lib/rules/node/express/index.js
+++ b/lib/rules/node/express/index.js
@@ -1,0 +1,8 @@
+const openApiSpecRules = require('./open-api-spec/index.js');
+// Add other sub-categories of express if any
+
+module.exports = {
+  rules: {
+    ...openApiSpecRules.rules,
+  },
+};

--- a/lib/rules/node/express/open-api-spec/index.js
+++ b/lib/rules/node/express/open-api-spec/index.js
@@ -1,0 +1,8 @@
+const httpStatusCode = require('./plugin/http-status-code');
+
+module.exports = {
+  rules: {
+    ...httpStatusCode.rules,
+    // ...add other express rules here in the future
+  },
+};

--- a/lib/rules/node/express/open-api-spec/plugin/http-status-code.js
+++ b/lib/rules/node/express/open-api-spec/plugin/http-status-code.js
@@ -1,0 +1,272 @@
+const knownExpressMethods = new Set([
+  'get',
+  'post',
+  'put',
+  'delete',
+  'patch',
+  'options',
+  'head',
+  'all',
+  'use',
+]);
+const responseSendMethods = new Set([
+  'send',
+  'json',
+  'end',
+  'sendStatus',
+  'redirect',
+]);
+const defaultStatusCodeByMethod = {
+  GET: [200],
+  POST: [201],
+  PUT: [200, 204],
+  PATCH: [200, 204],
+  DELETE: [200, 204],
+  OPTIONS: [200, 204],
+  HEAD: [200, 204],
+};
+
+module.exports = {
+  rules: {
+    'http-status-code': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Ensure that Express.js route handlers use appropriate HTTP status codes based on the HTTP method.',
+          category: 'Best Practices',
+          recommended: true,
+        },
+        fixable: null,
+        schema: [
+          {
+            type: 'object',
+            properties: {
+              responseObjectName: {
+                type: 'string',
+                description:
+                  'The name of the response object in route handlers.',
+                default: 'res',
+              },
+              validStatusCodesByMethod: {
+                type: 'object',
+                description:
+                  'Custom mapping of HTTP methods to arrays of allowed status codes.',
+                patternProperties: {
+                  '^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|ALL|USE)$': {
+                    type: 'array',
+                    items: { type: 'integer' },
+                    minItems: 1,
+                  },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+        messages: {
+          invalidStatusCode:
+            'Expected {{responseObjectName}}.status({{expectedCodes}}) for {{httpMethod}} request, but found {{responseObjectName}}.status({{actualCode}}).',
+          invalidSendStatusCode:
+            'Expected {{responseObjectName}}.sendStatus({{expectedCodes}}) for {{httpMethod}} request, but found {{responseObjectName}}.sendStatus({{actualCode}}).',
+        },
+      },
+      create: function (context) {
+        const options = context.options[0] || {};
+        const configuredResponseObjectName =
+          options.responseObjectName || 'res';
+        const validStatusCodesByMethod = {
+          ...defaultStatusCodeByMethod,
+          ...(options.validStatusCodesByMethod || {}),
+        };
+
+        const routeContextStack = [];
+
+        function getStatusCodeFromCall(callExpressionNode) {
+          if (
+            callExpressionNode.arguments.length > 0 &&
+            callExpressionNode.arguments[0].type === 'Literal' &&
+            typeof callExpressionNode.arguments[0].value === 'number'
+          ) {
+            return callExpressionNode.arguments[0].value;
+          }
+          return null;
+        }
+
+        function getRouteContext() {
+          return routeContextStack.length > 0
+            ? routeContextStack[routeContextStack.length - 1]
+            : null;
+        }
+
+        return {
+          CallExpression(node) {
+            // Part 1: Identify route definitions and push context to stack
+            if (node.callee.type === 'MemberExpression') {
+              const methodName = node.callee.property.name;
+
+              if (knownExpressMethods.has(methodName)) {
+                const handlerArg = node.arguments.find(
+                  arg =>
+                    arg &&
+                    (arg.type === 'FunctionExpression' ||
+                      arg.type === 'ArrowFunctionExpression')
+                );
+
+                if (handlerArg) {
+                  let responseObjectNameInHandler =
+                    configuredResponseObjectName;
+                  if (
+                    handlerArg.params &&
+                    handlerArg.params.length > 1 &&
+                    handlerArg.params[1].type === 'Identifier'
+                  ) {
+                    responseObjectNameInHandler = handlerArg.params[1].name;
+                  } else if (
+                    handlerArg.params &&
+                    handlerArg.params.length > 0 &&
+                    handlerArg.params[0].type === 'Identifier' &&
+                    handlerArg.params[0].name === configuredResponseObjectName
+                  ) {
+                    responseObjectNameInHandler = handlerArg.params[0].name;
+                  }
+
+                  routeContextStack.push({
+                    httpMethod: methodName.toUpperCase(),
+                    responseObjectName: responseObjectNameInHandler,
+                    handlerNode: handlerArg,
+                  });
+                }
+              }
+            }
+
+            // Part 2: Check for status calls if we are inside a known route handler
+            const currentRouteContext = getRouteContext();
+            if (
+              currentRouteContext &&
+              node.callee.type === 'MemberExpression'
+            ) {
+              let inHandlerScope = false;
+              let tempNode = node;
+              while (tempNode) {
+                if (tempNode === currentRouteContext.handlerNode) {
+                  inHandlerScope = true;
+                  break;
+                }
+                tempNode = tempNode.parent;
+              }
+
+              if (inHandlerScope) {
+                let actualCode = null;
+                let reportNode = node; // The CallExpression node being visited (e.g., .send(), .json(), .sendStatus())
+                let statusSettingNode = null; // The node that *sets* the status, e.g. .status(XXX) or .sendStatus(XXX)
+                let messageId = 'invalidStatusCode';
+
+                // Case 1: res.sendStatus(code)
+                if (
+                  node.callee.object.type === 'Identifier' &&
+                  node.callee.object.name ===
+                    currentRouteContext.responseObjectName &&
+                  node.callee.property.name === 'sendStatus'
+                ) {
+                  statusSettingNode = node; // The sendStatus call itself
+                  messageId = 'invalidSendStatusCode';
+                }
+                // Case 2: Patterns ending in .send(), .json(), .end() that might be preceded by .status()
+                else if (
+                  responseSendMethods.has(node.callee.property.name) &&
+                  node.callee.property.name !== 'sendStatus' && // Handled above
+                  node.callee.property.name !== 'redirect'
+                ) {
+                  // Redirects might have different status logic
+
+                  let objectOfSend = node.callee.object;
+
+                  // Check if objectOfSend is itself a CallExpression like someFormOf.status(code)
+                  if (
+                    objectOfSend.type === 'CallExpression' &&
+                    objectOfSend.callee.type === 'MemberExpression' &&
+                    objectOfSend.callee.property.name === 'status'
+                  ) {
+                    // objectOfSend is the LAST .status(code) in the chain before .send()
+                    // Now, we need to verify its base is the response object
+                    let baseObject = objectOfSend.callee.object;
+                    while (
+                      baseObject.type === 'CallExpression' &&
+                      baseObject.callee.type === 'MemberExpression' &&
+                      baseObject.callee.property.name === 'status'
+                    ) {
+                      baseObject = baseObject.callee.object;
+                    }
+
+                    if (
+                      baseObject.type === 'Identifier' &&
+                      baseObject.name === currentRouteContext.responseObjectName
+                    ) {
+                      statusSettingNode = objectOfSend;
+                    } else {
+                    }
+                  } else {
+                  }
+                }
+
+                if (statusSettingNode) {
+                  actualCode = getStatusCodeFromCall(statusSettingNode);
+                  reportNode =
+                    statusSettingNode.arguments.length > 0 &&
+                    statusSettingNode.arguments[0].type === 'Literal'
+                      ? statusSettingNode.arguments[0]
+                      : statusSettingNode;
+                }
+
+                if (
+                  actualCode !== null &&
+                  validStatusCodesByMethod[currentRouteContext.httpMethod]
+                ) {
+                  const expectedCodes =
+                    validStatusCodesByMethod[currentRouteContext.httpMethod];
+                  const isErrorCode = actualCode >= 400 && actualCode <= 599;
+
+                  if (!isErrorCode && !expectedCodes.includes(actualCode)) {
+                    context.report({
+                      node: reportNode,
+                      messageId: messageId,
+                      data: {
+                        responseObjectName:
+                          currentRouteContext.responseObjectName,
+                        httpMethod: currentRouteContext.httpMethod,
+                        actualCode: String(actualCode),
+                        expectedCodes: expectedCodes.join(' or '),
+                      },
+                    });
+                  } else {
+                  }
+                } else if (actualCode !== null) {
+                }
+              }
+            }
+          },
+          'FunctionExpression:exit'(node) {
+            const currentRouteContext = getRouteContext();
+            if (
+              currentRouteContext &&
+              currentRouteContext.handlerNode === node
+            ) {
+              // const popped = routeContextStack.pop();
+            }
+          },
+          'ArrowFunctionExpression:exit'(node) {
+            const currentRouteContext = getRouteContext();
+            if (
+              currentRouteContext &&
+              currentRouteContext.handlerNode === node
+            ) {
+              // const popped = routeContextStack.pop();
+            }
+          },
+        };
+      },
+    },
+  },
+};

--- a/lib/rules/node/index.js
+++ b/lib/rules/node/index.js
@@ -1,0 +1,9 @@
+// ... any existing node rules ...
+const expressRules = require('./express/index.js');
+
+module.exports = {
+  rules: {
+    // ... existing node rules ...
+    ...expressRules.rules,
+  },
+};

--- a/lib/rules/node/index.js
+++ b/lib/rules/node/index.js
@@ -1,9 +1,7 @@
-// ... any existing node rules ...
 const expressRules = require('./express/index.js');
 
 module.exports = {
   rules: {
-    // ... existing node rules ...
     ...expressRules.rules,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12262,7 +12262,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/test/express/http-status-code.test.js
+++ b/test/express/http-status-code.test.js
@@ -1,0 +1,126 @@
+const { RuleTester } = require('eslint');
+// const plugin = require('../../index'); // Assuming top-level index exports all rules
+// const rule = plugin.rules['http-status-code'];
+const rule =
+  require('../../lib/rules/node/express/open-api-spec/plugin/http-status-code')
+    .rules['http-status-code'];
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    globals: {
+      // Common Express globals
+      app: 'writable',
+      router: 'writable',
+      require: 'readonly',
+      module: 'readonly',
+      process: 'readonly',
+      console: 'readonly',
+    },
+  },
+});
+
+const defaultErrorMessage = (method, expected, actual, resName = 'res') =>
+  `Expected ${resName}.status(${expected.join(' or ')}) for ${method} request, but found ${resName}.status(${actual}).`;
+
+const sendStatusErrorMessage = (method, expected, actual, resName = 'res') =>
+  `Expected ${resName}.sendStatus(${expected.join(' or ')}) for ${method} request, but found ${resName}.sendStatus(${actual}).`;
+
+ruleTester.run('http-status-code', rule, {
+  valid: [
+    // Default GET
+    "app.get('/users', (req, res) => { res.status(200).send('Ok'); });",
+    "router.get('/items', (req, res) => { res.status(200).json([]); });",
+    // Default POST
+    "app.post('/users', (req, res) => { res.status(201).send('Created'); });",
+    // Default DELETE
+    "app.delete('/users/:id', (req, res) => { res.status(204).end(); });",
+    "app.delete('/users/:id', (req, res) => { res.status(200).send('Deleted OK'); });",
+    // Default PUT
+    "app.put('/users/:id', (req, res) => { res.status(200).send('Updated'); });",
+    "app.put('/users/:id', (req, res) => { res.status(204).send(); });",
+    // Default PATCH
+    "app.patch('/users/:id', (req, res) => { res.status(200).json({partial: true}); });",
+    "app.patch('/users/:id', (req, res) => { res.status(204).end(); });",
+    // res.sendStatus
+    "app.get('/status', (req, res) => { res.sendStatus(200); });",
+    "app.post('/status', (req, res) => { res.sendStatus(201); });",
+    // Conditional status
+    "app.get('/conditional', (req, res) => { if (req.query.err) { res.status(500).send('Error'); } else { res.status(200).send('OK'); } });",
+    // No explicit status (Express defaults to 200, rule doesn't check this case currently)
+    "app.get('/implicit', (req, res) => { res.send('Ok by default'); });",
+    // Custom response object name
+    {
+      code: "app.get('/custom', (req, reply) => { reply.status(200).send('Ok'); });",
+      options: [{ responseObjectName: 'reply' }],
+    },
+    // Custom status codes
+    {
+      code: "app.post('/custom-post', (req, res) => { res.status(200).send('Ok'); });",
+      options: [{ validStatusCodesByMethod: { POST: [200, 202] } }],
+    },
+    // Chained .status().status().send() - last one should count
+    "app.get('/chained-status', (req, res) => { res.status(500).status(200).send('Final is 200'); });",
+    // Handler as a separate function
+    `
+      function getUserHandler(req, res) { res.status(200).json({}); }
+      app.get('/user-handler', getUserHandler);
+    `,
+    // Methods not in default config (e.g. all, use) - should not error if no res.status()
+    "app.all('/all-path', (req, res, next) => { next(); });",
+    "app.use('/middleware', (req, res, next) => { res.header('X-Custom', 'true'); next(); });",
+    // Method not in default config, but with res.status() - should not error IF that method has no default config
+    // To test this properly, you'd need a method NOT in DEFAULT_STATUS_CODES_BY_METHOD
+    // e.g., if 'TRACE' was a known express method but not in defaults
+    // "app.trace('/trace-path', (req, res) => { res.status(200).send(); });", // Assuming TRACE has no default expectations
+  ],
+  invalid: [
+    {
+      code: "app.get('/users', (req, res) => { res.status(201).send('Wrong'); });",
+      errors: [{ message: defaultErrorMessage('GET', [200], 201) }],
+    },
+    {
+      code: "router.post('/items', (req, res) => { res.status(200).json({}); });",
+      errors: [{ message: defaultErrorMessage('POST', [201], 200) }],
+    },
+    {
+      code: "app.delete('/users/:id', (req, res) => { res.status(201).end(); });",
+      errors: [{ message: defaultErrorMessage('DELETE', [200, 204], 201) }],
+    },
+    {
+      code: "app.put('/users/:id', (req, res) => { res.status(201).send(); });",
+      errors: [{ message: defaultErrorMessage('PUT', [200, 204], 201) }],
+    },
+    {
+      code: "app.patch('/users/:id', (req, res) => { res.status(201).json({}); });",
+      errors: [{ message: defaultErrorMessage('PATCH', [200, 204], 201) }],
+    },
+    // res.sendStatus
+    {
+      code: "app.get('/status-err', (req, res) => { res.sendStatus(201); });", // Changed 404 to 201
+      errors: [{ message: sendStatusErrorMessage('GET', [200], 201) }], // Error message reflects 201
+    },
+    {
+      code: "app.post('/status-err-post', (req, res) => { res.sendStatus(200); });",
+      errors: [{ message: sendStatusErrorMessage('POST', [201], 200) }],
+    },
+    // Custom response object name
+    {
+      code: "app.get('/custom-err', (req, reply) => { reply.status(204).send('Err'); });", // Changed 400 to 204
+      options: [{ responseObjectName: 'reply' }],
+      errors: [{ message: defaultErrorMessage('GET', [200], 204, 'reply') }], // Error message reflects 204
+    },
+    // Custom status codes, but still wrong
+    {
+      code: "app.post('/custom-post-err', (req, res) => { res.status(200).send('Bad'); });", // Changed 400 to 200
+      options: [{ validStatusCodesByMethod: { POST: [202] } }],
+      errors: [{ message: defaultErrorMessage('POST', [202], 200) }], // Error message reflects 200
+    },
+    // Chained status, last one is wrong
+    {
+      code: "app.get('/chained-status-err', (req, res) => { res.status(200).status(201).send('Forbidden'); });", // 201 is not 200 for GET
+      errors: [{ message: defaultErrorMessage('GET', [200], 201) }],
+    },
+  ],
+});


### PR DESCRIPTION
---
name: Pull Request
about: Submit a pull request to propose changes to the project
title: 'Validate HTTP Status Code Usage'
labels: 'New rule
assignees: Sanghamitra Dash
---

**Description**

This pull request introduces a new ESLint rule, hub/http-status-code (or its final namespaced equivalent), designed to ensure that Express.js route handlers utilize appropriate HTTP status codes based on the HTTP method being handled. Adherence to standard HTTP semantics is crucial for building predictable and maintainable RESTful APIs.
The rule statically analyzes route handlers to identify calls like res.status(code).send(), res.status(code).json(), res.status(code).end(), and res.sendStatus(code). It then validates the used status code against a configurable list of expected codes for the specific HTTP method (GET, POST, PUT, DELETE, etc.).
For example, by default:
- GET requests are expected to return a 200 OK.
- POST requests (for resource creation) are expected to return a 201 Created.
- DELETE requests are expected to return 200 OK or 204 No Content.

This helps prevent common issues such as a POST request incorrectly returning a 200 OK instead of 201 Created, or a GET request returning a misleading status. The rule focuses on validating "success" or standard operational status codes (1xx, 2xx, 3xx) and ignores 4xx/5xx client/server error codes, as these are generally permissible for any method when an error occurs.

**key features**
- Parses common Express route definitions (app.METHOD(), router.METHOD()).
- Identifies various response sending patterns including chained status calls (e.g., res.status(A).status(B).send()).
- Provides default expected status codes for common HTTP methods (GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD).
- Allows configuration to:
     - Specify a custom response object name (if not res).
     - Override or extend the default valid status codes for each HTTP method.
- Delivers clear error messages indicating the expected vs. actual status code.

**Related Issue**
- Closes #60 "[NEW RULE]: Validate HTTP Status Code Usage"



**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please specify):

**How to Test**
npm test -- test/express/http-status-code.test.js

**Checklist**

- [ ] My code follows the project's coding style.
- [ ] I have updated the documentation as necessary.
- [ ] I have added tests to cover my changes.
- [ ] All existing and new tests pass.

**Additional Notes**
- The rule is currently configured to ignore 4xx and 5xx status codes when validating against the validStatusCodesByMethod list, focusing on ensuring correct "success" or standard operational codes.
- The file path for the rule is lib/rules/node/express/open-api-spec/plugin/http-status-code.js. Corresponding index files have been updated/created to ensure it's correctly exported by the plugin. (Adjust this note if the path is simplified).
- Consideration for res.redirect() status codes and implicit statuses (e.g., res.send() defaulting to 200) could be future enhancements if deemed necessary.

---

Thank you for your contribution!
